### PR TITLE
added vegan options to lasagna recipe, fixes #6

### DIFF
--- a/mains/vegetarian-lasagna.md
+++ b/mains/vegetarian-lasagna.md
@@ -1,14 +1,14 @@
-# Vegetarian lasagna recipe
-
+# Vegetarian lasagna recipe (now with vegan options)
+Vegan options are added in parentheses starting with a V:, i.e., milk (V: soy milk)
 
 ## Ingredients
 
 - **9-12** no-boil lasagna noodles
 - **1** large jar (about 24 oz) of marinara sauce
-- **15 oz** ricotta cheese
-- **1** egg
-- **1/2 cup** grated Parmesan cheese
-- **2 cups** shredded mozzarella cheese
+- **15 oz** ricotta cheese (V: silken tofu)
+- **1** egg (V: silken tofu)
+- **1/2 cup** grated Parmesan cheese (V: vegan parmesan)
+- **2 cups** shredded mozzarella cheese (V: vegan mozarella)
 - **1 lb** fresh spinach, rinsed and chopped (or use frozen spinach, thawed and drained)
 - **1** medium zucchini, thinly sliced
 - **1** bell pepper, diced
@@ -33,16 +33,16 @@
    - Remove from heat and set aside.
 
 3. **Mix Cheeses:**
-   - In a bowl, mix together the ricotta cheese, egg, half of the grated Parmesan cheese, and a pinch of salt and pepper. Set aside.
+   - In a bowl, mix together the ricotta and egg (V: silken tofu) with half of the grated parmesan, and a pinch of salt and pepper. Set aside.
 
 4. **Assemble Lasagna:**
    - Spread a thin layer of marinara sauce over the bottom of the baking dish.
    - Place a layer of lasagna noodles over the sauce.
-   - Spread half of the ricotta mixture over the noodles.
-   - Add half of the sautéed vegetables over the ricotta layer.
-   - Sprinkle a layer of mozzarella cheese.
-   - Repeat the layers: sauce, noodles, ricotta mixture, vegetables, and mozzarella cheese.
-   - Top with a final layer of noodles, the remaining sauce, and sprinkle the rest of the Parmesan and mozzarella cheeses.
+   - Spread half of the ricotta (V: tofu) mixture over the noodles.
+   - Add half of the sautéed vegetables over the ricotta (V: tofu) layer.
+   - Sprinkle a layer of mozzarella.
+   - Repeat the layers: sauce, noodles, ricotta (V: tofu) mixture, vegetables, and mozzarella.
+   - Top with a final layer of noodles, the remaining sauce, and sprinkle the rest of the parmesan and mozzarella.
 
 5. **Bake:**
    - Cover the lasagna with aluminum foil and bake in the preheated oven for 25 minutes.


### PR DESCRIPTION
- Vegan replacements for cheese and egg are added in parentheses, leaving the original recipe intact. 
- Some instances of the word cheese were removed (after the words mozzarella and parmesan), so that the instructions can apply both to the cheeses and commercially available vegan replacements. 
- Slightly changed phrasing in some places to avoid confusion when it comes to what is replaced